### PR TITLE
添加积分Log, 修复部分XSS漏洞,注册邮件可配置

### DIFF
--- a/src/main/java/co/yiiu/config/MailTemplateConfig.java
+++ b/src/main/java/co/yiiu/config/MailTemplateConfig.java
@@ -1,0 +1,27 @@
+package co.yiiu.config;
+
+/**
+ * Created by teddyzhu.
+ * Copyright (c) 2017, All Rights Reserved.
+ */
+public class MailTemplateConfig {
+
+    private String subject;
+    private String content;
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/co/yiiu/config/ScoreEventConfig.java
+++ b/src/main/java/co/yiiu/config/ScoreEventConfig.java
@@ -1,0 +1,28 @@
+package co.yiiu.config;
+
+import com.google.common.collect.Maps;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by teddyzhu.
+ * Copyright (c) 2017, All Rights Reserved.
+ */
+@Configuration
+@ConfigurationProperties(prefix = "score")
+public class ScoreEventConfig {
+
+    private Map<String, String> template = Maps.newConcurrentMap();
+
+
+    public Map<String, String> getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(Map<String, String> template) {
+        this.template = template;
+    }
+}

--- a/src/main/java/co/yiiu/config/SiteConfig.java
+++ b/src/main/java/co/yiiu/config/SiteConfig.java
@@ -36,6 +36,8 @@ public class SiteConfig {
   private String newUserRole;
   private CookieConfig cookie;
 
+  private MailTemplateConfig mail;
+
   public boolean isSsl() {
     return ssl;
   }
@@ -218,5 +220,13 @@ public class SiteConfig {
 
   public void setCreateReplyScore(int createReplyScore) {
     this.createReplyScore = createReplyScore;
+  }
+
+  public MailTemplateConfig getMail() {
+    return mail;
+  }
+
+  public void setMail(MailTemplateConfig mail) {
+    this.mail = mail;
   }
 }

--- a/src/main/java/co/yiiu/core/util/FreemarkerUtil.java
+++ b/src/main/java/co/yiiu/core/util/FreemarkerUtil.java
@@ -60,9 +60,9 @@ public class FreemarkerUtil {
 
 
         try {
-            Template stringTemplte = configuration.getTemplate("");
-            cachedTemplate.put(template, stringTemplte);
-            return stringTemplte;
+            Template stringTemplate = configuration.getTemplate("");
+            cachedTemplate.put(template, stringTemplate);
+            return stringTemplate;
         } catch (IOException e) {
             e.printStackTrace();
             logger.error("get template error", e);

--- a/src/main/java/co/yiiu/core/util/FreemarkerUtil.java
+++ b/src/main/java/co/yiiu/core/util/FreemarkerUtil.java
@@ -1,0 +1,73 @@
+package co.yiiu.core.util;
+
+import co.yiiu.core.util.freemarker.StringTemplateLoader;
+import com.google.common.collect.Maps;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Created by teddyzhu.
+ * Copyright (c) 2017, All Rights Reserved.
+ */
+@Component
+public class FreemarkerUtil {
+
+
+    private final Log logger = LogFactory.getLog(FreemarkerUtil.class);
+
+
+    @Autowired
+    FreeMarkerConfigurer freeMarkerConfigurer;
+
+    private static final Map<String, Template> cachedTemplate = Maps.newConcurrentMap();
+
+    public String format(String template, Map<String, Object> objectMap) {
+        StringWriter writer = new StringWriter();
+        try {
+            getTemplateConfiguration(template).process(objectMap, writer);
+        } catch (TemplateException | IOException e) {
+            e.printStackTrace();
+            logger.error("render template error", e);
+        }
+        return writer.toString();
+    }
+
+    private Template getTemplateConfiguration(String template) {
+
+        if (cachedTemplate.containsKey(template)) {
+            return cachedTemplate.get(template);
+        }
+        Configuration configuration = null;
+        try {
+            configuration = freeMarkerConfigurer.createConfiguration();
+        } catch (IOException | TemplateException e) {
+            e.printStackTrace();
+            logger.error("get system configuration error", e);
+        }
+        configuration.setTemplateLoader(new StringTemplateLoader(template));
+        configuration.setDefaultEncoding("UTF-8");
+
+
+        try {
+            Template stringTemplte = configuration.getTemplate("");
+            cachedTemplate.put(template, stringTemplte);
+            return stringTemplte;
+        } catch (IOException e) {
+            e.printStackTrace();
+            logger.error("get template error", e);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/co/yiiu/core/util/freemarker/StringTemplateLoader.java
+++ b/src/main/java/co/yiiu/core/util/freemarker/StringTemplateLoader.java
@@ -1,0 +1,49 @@
+package co.yiiu.core.util.freemarker;
+
+import com.google.common.collect.Maps;
+import freemarker.cache.TemplateLoader;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Map;
+
+/**
+ * Created by teddyzhu.
+ * Copyright (c) 2017, All Rights Reserved.
+ */
+public class StringTemplateLoader implements TemplateLoader {
+    private static final String DEFAULT_TEMPLATE_KEY = "_default_template_key";
+    private Map templates = Maps.newConcurrentMap();
+
+    public StringTemplateLoader(String defaultTemplate) {
+        if (defaultTemplate != null && !defaultTemplate.equals("")) {
+            templates.put(DEFAULT_TEMPLATE_KEY, defaultTemplate);
+        }
+    }
+
+    @Override
+    public void closeTemplateSource(Object templateSource)
+            throws IOException {
+
+    }
+
+    @Override
+    public Object findTemplateSource(String name) throws IOException {
+        if (name == null || "".equals(name)) {
+            name = DEFAULT_TEMPLATE_KEY;
+        }
+        return templates.get(name);
+    }
+
+    @Override
+    public long getLastModified(Object templateSource) {
+        return 0;
+    }
+
+    @Override
+    public Reader getReader(Object templateSource, String encoding)
+            throws IOException {
+        return new StringReader((String) templateSource);
+    }
+}

--- a/src/main/java/co/yiiu/module/score/model/ScoreEventEnum.java
+++ b/src/main/java/co/yiiu/module/score/model/ScoreEventEnum.java
@@ -1,0 +1,31 @@
+package co.yiiu.module.score.model;
+
+/**
+ * Created by teddyzhu.
+ * Copyright (c) 2017, All Rights Reserved.
+ */
+public enum ScoreEventEnum {
+    DAILY_SIGN("每日签到", "dailySign"),
+    CREATE_TOPIC("发布主题", "createTopic"),
+    REPLY_TOPIC("回复主题", "replyTopic");
+
+    private String event;
+    private String name;
+
+    ScoreEventEnum(String event, String name) {
+        this.event = event;
+        this.name = name;
+    }
+
+    ScoreEventEnum(String event) {
+        this.event = event;
+    }
+
+    public String getEvent() {
+        return event;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/co/yiiu/module/score/model/ScoreEventEnum.java
+++ b/src/main/java/co/yiiu/module/score/model/ScoreEventEnum.java
@@ -7,7 +7,8 @@ package co.yiiu.module.score.model;
 public enum ScoreEventEnum {
     DAILY_SIGN("每日签到", "dailySign"),
     CREATE_TOPIC("发布主题", "createTopic"),
-    REPLY_TOPIC("回复主题", "replyTopic");
+    REPLY_TOPIC("回复主题", "replyTopic"),
+    REGISTER("注册","register");
 
     private String event;
     private String name;

--- a/src/main/java/co/yiiu/module/score/model/ScoreLog.java
+++ b/src/main/java/co/yiiu/module/score/model/ScoreLog.java
@@ -1,0 +1,109 @@
+package co.yiiu.module.score.model;
+
+import co.yiiu.core.util.Constants;
+import co.yiiu.module.user.model.User;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Created by teddyzhu.
+ * Copyright (c) 2017, All Rights Reserved.
+ */
+@Table(name = "yiiu_score_log")
+@Entity
+public class ScoreLog  implements Serializable {
+
+    @Id
+    @GeneratedValue
+    private int id;
+
+    /**
+     * 事件名
+     */
+    private String event;
+
+    /**
+     * 事件描述
+     */
+    @Column(name = "event_description")
+    private String eventDescription;
+
+    /**
+     * 变动积分
+     */
+    @Column(name = "change_score")
+    private int changeScore;
+
+    /**
+     * 变动积分余额
+     */
+    private int score;
+
+    //与用户的关联关系
+    @ManyToOne
+    @JoinColumn(nullable = false, name = "user_id")
+    private User user;
+
+    @Column(name = "in_time")
+    @JsonFormat(pattern = Constants.DATETIME_FORMAT)
+    private Date inTime;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Date getInTime() {
+        return inTime;
+    }
+
+    public void setInTime(Date inTime) {
+        this.inTime = inTime;
+    }
+
+    public String getEvent() {
+        return event;
+    }
+
+    public void setEvent(String event) {
+        this.event = event;
+    }
+
+    public String getEventDescription() {
+        return eventDescription;
+    }
+
+    public void setEventDescription(String eventDescription) {
+        this.eventDescription = eventDescription;
+    }
+
+    public int getChangeScore() {
+        return changeScore;
+    }
+
+    public void setChangeScore(int changeScore) {
+        this.changeScore = changeScore;
+    }
+
+    public int getScore() {
+        return score;
+    }
+
+    public void setScore(int score) {
+        this.score = score;
+    }
+}

--- a/src/main/java/co/yiiu/module/score/repository/ScoreLogRepository.java
+++ b/src/main/java/co/yiiu/module/score/repository/ScoreLogRepository.java
@@ -1,0 +1,25 @@
+package co.yiiu.module.score.repository;
+
+import co.yiiu.module.collect.model.Collect;
+import co.yiiu.module.score.model.ScoreLog;
+import co.yiiu.module.user.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Created by teddyzhu.
+ * Copyright (c) 2017, All Rights Reserved.
+ */
+@Repository
+public interface ScoreLogRepository extends JpaRepository<ScoreLog, Integer> {
+
+    Page<ScoreLog> findByUser(User user, Pageable pageable);
+
+}

--- a/src/main/java/co/yiiu/module/score/service/ScoreLogService.java
+++ b/src/main/java/co/yiiu/module/score/service/ScoreLogService.java
@@ -1,0 +1,55 @@
+package co.yiiu.module.score.service;
+
+import co.yiiu.config.FreemarkerConfig;
+import co.yiiu.config.ScoreEventConfig;
+import co.yiiu.core.util.FreemarkerUtil;
+import co.yiiu.module.collect.model.Collect;
+import co.yiiu.module.score.model.ScoreEventEnum;
+import co.yiiu.module.score.model.ScoreLog;
+import co.yiiu.module.score.repository.ScoreLogRepository;
+import co.yiiu.module.user.model.User;
+import com.google.common.collect.Maps;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by teddyzhu.
+ * Copyright (c) 2017, All Rights Reserved.
+ */
+@Service
+@CacheConfig(cacheNames = "scoreLogs")
+public class ScoreLogService {
+
+    @Autowired
+    FreemarkerUtil freemarkerUtil;
+
+    @Autowired
+    ScoreLogRepository scoreLogRepository;
+    @Autowired
+    ScoreEventConfig scoreEventConfig;
+
+    @CacheEvict(allEntries = true)
+    public void save(ScoreLog scoreLog) {
+        scoreLogRepository.save(scoreLog);
+    }
+
+    @Cacheable
+    public Page<ScoreLog> findScoreByUser(Integer p, int size, User user) {
+        Sort sort = new Sort(new Sort.Order(Sort.Direction.DESC, "inTime"));
+        Pageable pageable = new PageRequest(p == null ? 0 : p-1, size, sort);
+        return scoreLogRepository.findByUser(user, pageable);
+    }
+
+}

--- a/src/main/java/co/yiiu/web/front/IndexController.java
+++ b/src/main/java/co/yiiu/web/front/IndexController.java
@@ -56,387 +56,387 @@ import java.util.*;
 @Controller
 public class IndexController extends BaseController {
 
-  private Logger log = LoggerFactory.getLogger(IndexController.class);
+    private Logger log = LoggerFactory.getLogger(IndexController.class);
 
-  @Autowired
-  private TopicSearch topicSearch;
-  @Autowired
-  private UserService userService;
-  @Autowired
-  private SiteConfig siteConfig;
-  @Autowired
-  private Identicon identicon;
-  @Autowired
-  private FileUtil fileUtil;
-  @Autowired
-  private JavaMailSender javaMailSender;
-  @Autowired
-  private CodeService codeService;
-  @Autowired
-  private Environment env;
-  @Autowired
-  private AttendanceService attendanceService;
-  @Autowired
-  private RoleService roleService;
-  @Autowired
-  FreemarkerUtil freemarkerUtil;
-  @Autowired
-  ScoreEventConfig scoreEventConfig;
+    @Autowired
+    private TopicSearch topicSearch;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private SiteConfig siteConfig;
+    @Autowired
+    private Identicon identicon;
+    @Autowired
+    private FileUtil fileUtil;
+    @Autowired
+    private JavaMailSender javaMailSender;
+    @Autowired
+    private CodeService codeService;
+    @Autowired
+    private Environment env;
+    @Autowired
+    private AttendanceService attendanceService;
+    @Autowired
+    private RoleService roleService;
+    @Autowired
+    FreemarkerUtil freemarkerUtil;
+    @Autowired
+    ScoreEventConfig scoreEventConfig;
 
-  @Autowired
-  ScoreLogService scoreLogService;
-  /**
-   * 首页
-   *
-   * @return
-   */
-  @GetMapping("/")
-  public String index(String tab, Integer p, Model model) {
-    model.addAttribute("p", p);
-    model.addAttribute("tab", tab);
-    return "front/index";
-  }
+    @Autowired
+    ScoreLogService scoreLogService;
 
-  /**
-   * top 100 user score
-   *
-   * @return
-   */
-  @GetMapping("/top100")
-  public String top100() {
-    return "front/top100";
-  }
+    /**
+     * 首页
+     *
+     * @return
+     */
+    @GetMapping("/")
+    public String index(String tab, Integer p, Model model) {
+        model.addAttribute("p", p);
+        model.addAttribute("tab", tab);
+        return "front/index";
+    }
 
-  /**
-   * 搜索
-   *
-   * @param p
-   * @param q
-   * @param model
-   * @return
-   */
-  @GetMapping("/search")
-  public String search(Integer p, String q, Model model) {
-    Page<Topic> page = topicSearch.search(p == null ? 1 : p, siteConfig.getPageSize(), q);
-    model.addAttribute("page", page);
-    model.addAttribute("q", q);
-    return "front/search";
-  }
+    /**
+     * top 100 user score
+     *
+     * @return
+     */
+    @GetMapping("/top100")
+    public String top100() {
+        return "front/top100";
+    }
 
-  /**
-   * Daily attendance
-   *
-   * @param request
-   * @return
-   */
-  @GetMapping("/attendance")
-  @ResponseBody
-  public Result attendance(HttpServletRequest request, HttpServletResponse response) {
-    String attendanceValue = StrUtil.getCookie(request, siteConfig.getCookie().getAttendanceName());
+    /**
+     * 搜索
+     *
+     * @param p
+     * @param q
+     * @param model
+     * @return
+     */
+    @GetMapping("/search")
+    public String search(Integer p, String q, Model model) {
+        Page<Topic> page = topicSearch.search(p == null ? 1 : p, siteConfig.getPageSize(), q);
+        model.addAttribute("page", page);
+        model.addAttribute("q", q);
+        return "front/search";
+    }
 
-    Random random = new Random();
-    Date now = new Date();
+    /**
+     * Daily attendance
+     *
+     * @param request
+     * @return
+     */
+    @GetMapping("/attendance")
+    @ResponseBody
+    public Result attendance(HttpServletRequest request, HttpServletResponse response) {
+        String attendanceValue = StrUtil.getCookie(request, siteConfig.getCookie().getAttendanceName());
 
-    User user = getUser();
-    Date date1 = DateUtil.string2Date(
-        DateUtil.formatDateTime(now, DateUtil.FORMAT_DATE) + " 00:00:00",
-        DateUtil.FORMAT_DATETIME
-    );
-    Date date2 = DateUtil.string2Date(
-        DateUtil.formatDateTime(now, DateUtil.FORMAT_DATE) + " 23:59:59",
-        DateUtil.FORMAT_DATETIME
-    );
+        Random random = new Random();
+        Date now = new Date();
 
-    if (StringUtils.isEmpty(attendanceValue) || !"1".equals(attendanceValue)) {
-      Attendance attendance = attendanceService.findByUserAndInTime(user, date1, date2);
-      if (attendance == null) {
-        int score = random.nextInt(51) + 1; // random score in 1 - 50
-        // save attendance record
-        attendance = new Attendance();
-        attendance.setInTime(now);
-        attendance.setScore(score);
-        attendance.setUser(user);
-        attendanceService.save(attendance);
+        User user = getUser();
+        Date date1 = DateUtil.string2Date(
+                DateUtil.formatDateTime(now, DateUtil.FORMAT_DATE) + " 00:00:00",
+                DateUtil.FORMAT_DATETIME
+        );
+        Date date2 = DateUtil.string2Date(
+                DateUtil.formatDateTime(now, DateUtil.FORMAT_DATE) + " 23:59:59",
+                DateUtil.FORMAT_DATETIME
+        );
 
-        // update user score
-        user.setScore(user.getScore() + score);
+        if (StringUtils.isEmpty(attendanceValue) || !"1".equals(attendanceValue)) {
+            Attendance attendance = attendanceService.findByUserAndInTime(user, date1, date2);
+            if (attendance == null) {
+                int score = random.nextInt(51) + 1; // random score in 1 - 50
+                // save attendance record
+                attendance = new Attendance();
+                attendance.setInTime(now);
+                attendance.setScore(score);
+                attendance.setUser(user);
+                attendanceService.save(attendance);
+
+                // update user score
+                user.setScore(user.getScore() + score);
+                userService.save(user);
+
+                // 记录积分log
+                ScoreLog scoreLog = new ScoreLog();
+
+                scoreLog.setInTime(new Date());
+                scoreLog.setEvent(ScoreEventEnum.DAILY_SIGN.getEvent());
+                scoreLog.setChangeScore(score);
+                scoreLog.setScore(user.getScore());
+                scoreLog.setUser(user);
+
+                Map<String, Object> params = Maps.newHashMap();
+                params.put("scoreLog", scoreLog);
+                params.put("user", user);
+                String des = freemarkerUtil.format(scoreEventConfig.getTemplate().get(ScoreEventEnum.DAILY_SIGN.getName()), params);
+                scoreLog.setEventDescription(des);
+                scoreLogService.save(scoreLog);
+
+                // write remark to cookie
+                writeAttendanceCookie(response, now, date2);
+
+                return Result.success(score);
+            }
+        }
+        writeAttendanceCookie(response, now, date2);
+        return Result.error("你今天已经签到过了");
+    }
+
+    private void writeAttendanceCookie(HttpServletResponse response, Date date1, Date date2) {
+        int maxAge = Math.abs((int) ((date2.getTime() - date1.getTime()) / 1000)); // second
+        StrUtil.setCookie(
+                response,
+                siteConfig.getCookie().getAttendanceName(), // name
+                "1", // value
+                maxAge, // maxAge
+                true, // httpOnly
+                siteConfig.getCookie().getDomain(), // domain
+                "/" // path
+        );
+    }
+
+    /**
+     * upload file
+     *
+     * @param file
+     * @return
+     */
+    @PostMapping("/upload")
+    @ResponseBody
+    public Result upload(@RequestParam("file") MultipartFile file) {
+        if (!file.isEmpty()) {
+            try {
+                if (fileUtil.getTotalSizeOfFilesInDir(new File(siteConfig.getUploadPath() + getUsername())) + file.getSize()
+                        > getUser().getSpaceSize() * 1024 * 1024)
+                    return Result.error("你的上传空间不够了，请用积分去用户中心兑换");
+                String requestUrl = fileUtil.uploadFile(file, FileUploadEnum.FILE, getUsername());
+                return Result.success(requestUrl);
+            } catch (IOException e) {
+                e.printStackTrace();
+                return Result.error("上传失败");
+            }
+        }
+        return Result.error("文件不存在");
+    }
+
+    /**
+     * 进入登录页
+     *
+     * @return
+     */
+    @GetMapping("/login")
+    public String toLogin(String s, Model model, HttpServletResponse response) {
+        if (getUser() != null) {
+            return redirect(response, "/");
+        }
+        model.addAttribute("s", s);
+        return "front/login";
+    }
+
+    /**
+     * 进入注册页面
+     *
+     * @return
+     */
+    @GetMapping("/register")
+    public String toRegister(HttpServletResponse response) {
+        if (getUser() != null) {
+            return redirect(response, "/");
+        }
+        return "front/register";
+    }
+
+    /**
+     * 注册验证
+     *
+     * @param username
+     * @param password
+     * @return
+     */
+    @PostMapping("/register")
+    @ResponseBody
+    public Result register(String username, String password, String email, String emailCode, String code,
+                           HttpSession session) throws ApiException {
+
+        String genCaptcha = (String) session.getAttribute("index_code");
+        if (StringUtils.isEmpty(code)) throw new ApiException("验证码不能为空");
+
+        if (!genCaptcha.toLowerCase().equals(code.toLowerCase())) throw new ApiException("验证码错误");
+        if (StringUtils.isEmpty(username)) throw new ApiException("用户名不能为空");
+        if (StringUtils.isEmpty(password)) throw new ApiException("密码不能为空");
+        if (StringUtils.isEmpty(email)) throw new ApiException("邮箱不能为空");
+
+        if (!StrUtil.check(username, StrUtil.userNameCheck)) throw new ApiException("用户名不合法");
+
+        User user = userService.findByUsername(username);
+        if (user != null) throw new ApiException("用户名已经被注册");
+
+        User user_email = userService.findByEmail(email);
+        if (user_email != null) throw new ApiException("邮箱已经被使用");
+
+        int validateResult = codeService.validateCode(emailCode, CodeEnum.EMAIL);
+        if (validateResult == 1) throw new ApiException("邮箱验证码不正确");
+        if (validateResult == 2) throw new ApiException("邮箱验证码已过期");
+        if (validateResult == 3) throw new ApiException("邮箱验证码已经被使用");
+
+        Date now = new Date();
+        // generator avatar
+        String avatar = identicon.generator(username);
+
+        user = new User();
+        user.setEmail(email);
+        user.setUsername(username);
+        user.setPassword(new BCryptPasswordEncoder().encode(password));
+        user.setInTime(now);
+        user.setBlock(false);
+        user.setToken(UUID.randomUUID().toString());
+        user.setAvatar(avatar);
+        user.setAttempts(0);
+        user.setScore(siteConfig.getScore());
+        user.setSpaceSize(siteConfig.getUserUploadSpaceSize());
+
+        // set user's role
+        Role role = roleService.findByName(siteConfig.getNewUserRole());
+        Set roles = new HashSet();
+        roles.add(role);
+        user.setRoles(roles);
+
         userService.save(user);
 
-        // 记录积分log
-        ScoreLog scoreLog = new ScoreLog();
+        //region 记录积分log
+        if (siteConfig.getScore() != 0) {
+            ScoreLog scoreLog = new ScoreLog();
 
-        scoreLog.setInTime(new Date());
-        scoreLog.setEvent(ScoreEventEnum.DAILY_SIGN.getEvent());
-        scoreLog.setChangeScore(score);
-        scoreLog.setScore(user.getScore());
-        scoreLog.setUser(user);
+            scoreLog.setInTime(new Date());
+            scoreLog.setEvent(ScoreEventEnum.REGISTER.getEvent());
+            scoreLog.setChangeScore(user.getScore());
+            scoreLog.setScore(user.getScore());
+            scoreLog.setUser(user);
 
-        Map<String, Object> params = Maps.newHashMap();
-        params.put("scoreLog", scoreLog);
-        params.put("user", user);
-        String des = freemarkerUtil.format(scoreEventConfig.getTemplate().get(ScoreEventEnum.DAILY_SIGN.getName()), params);
-        scoreLog.setEventDescription(des);
-        scoreLogService.save(scoreLog);
+            Map<String, Object> params = Maps.newHashMap();
+            params.put("scoreLog", scoreLog);
+            params.put("user", user);
+            String des = freemarkerUtil.format(scoreEventConfig.getTemplate().get(ScoreEventEnum.REGISTER.getName()), params);
+            scoreLog.setEventDescription(des);
+            scoreLogService.save(scoreLog);
 
-        // write remark to cookie
-        writeAttendanceCookie(response, now, date2);
-
-        return Result.success(score);
-      }
-    }
-    writeAttendanceCookie(response, now, date2);
-    return Result.error("你今天已经签到过了");
-  }
-
-  private void writeAttendanceCookie(HttpServletResponse response, Date date1, Date date2) {
-    int maxAge = Math.abs((int) ((date2.getTime() - date1.getTime()) / 1000)); // second
-    StrUtil.setCookie(
-        response,
-        siteConfig.getCookie().getAttendanceName(), // name
-        "1", // value
-        maxAge, // maxAge
-        true, // httpOnly
-        siteConfig.getCookie().getDomain(), // domain
-        "/" // path
-    );
-  }
-
-  /**
-   * upload file
-   *
-   * @param file
-   * @return
-   */
-  @PostMapping("/upload")
-  @ResponseBody
-  public Result upload(@RequestParam("file") MultipartFile file) {
-    if (!file.isEmpty()) {
-      try {
-        if (fileUtil.getTotalSizeOfFilesInDir(new File(siteConfig.getUploadPath() + getUsername())) + file.getSize()
-            > getUser().getSpaceSize() * 1024 * 1024)
-          return Result.error("你的上传空间不够了，请用积分去用户中心兑换");
-        String requestUrl = fileUtil.uploadFile(file, FileUploadEnum.FILE, getUsername());
-        return Result.success(requestUrl);
-      } catch (IOException e) {
-        e.printStackTrace();
-        return Result.error("上传失败");
-      }
-    }
-    return Result.error("文件不存在");
-  }
-
-  /**
-   * 进入登录页
-   *
-   * @return
-   */
-  @GetMapping("/login")
-  public String toLogin(String s, Model model, HttpServletResponse response) {
-    if (getUser() != null) {
-      return redirect(response, "/");
-    }
-    model.addAttribute("s", s);
-    return "front/login";
-  }
-
-  /**
-   * 进入注册页面
-   *
-   * @return
-   */
-  @GetMapping("/register")
-  public String toRegister(HttpServletResponse response) {
-    if (getUser() != null) {
-      return redirect(response, "/");
-    }
-    return "front/register";
-  }
-
-  /**
-   * 注册验证
-   *
-   * @param username
-   * @param password
-   * @return
-   */
-  @PostMapping("/register")
-  @ResponseBody
-  public Result register(String username, String password, String email, String emailCode, String code,
-                         HttpSession session) throws ApiException {
-
-    String genCaptcha = (String) session.getAttribute("index_code");
-    if (StringUtils.isEmpty(code)) throw new ApiException("验证码不能为空");
-
-    if (!genCaptcha.toLowerCase().equals(code.toLowerCase())) throw new ApiException("验证码错误");
-    if (StringUtils.isEmpty(username)) throw new ApiException("用户名不能为空");
-    if (StringUtils.isEmpty(password)) throw new ApiException("密码不能为空");
-    if (StringUtils.isEmpty(email)) throw new ApiException("邮箱不能为空");
-
-    if (!StrUtil.check(username, StrUtil.userNameCheck)) throw new ApiException("用户名不合法");
-
-    User user = userService.findByUsername(username);
-    if (user != null) throw new ApiException("用户名已经被注册");
-
-    User user_email = userService.findByEmail(email);
-    if (user_email != null) throw new ApiException("邮箱已经被使用");
-
-    int validateResult = codeService.validateCode(emailCode, CodeEnum.EMAIL);
-    if (validateResult == 1) throw new ApiException("邮箱验证码不正确");
-    if (validateResult == 2) throw new ApiException("邮箱验证码已过期");
-    if (validateResult == 3) throw new ApiException("邮箱验证码已经被使用");
-
-    Date now = new Date();
-    // generator avatar
-    String avatar = identicon.generator(username);
-
-    user = new User();
-    user.setEmail(email);
-    user.setUsername(username);
-    user.setPassword(new BCryptPasswordEncoder().encode(password));
-    user.setInTime(now);
-    user.setBlock(false);
-    user.setToken(UUID.randomUUID().toString());
-    user.setAvatar(avatar);
-    user.setAttempts(0);
-    user.setScore(siteConfig.getScore());
-    user.setSpaceSize(siteConfig.getUserUploadSpaceSize());
-
-    // set user's role
-    Role role = roleService.findByName(siteConfig.getNewUserRole());
-    Set roles = new HashSet();
-    roles.add(role);
-    user.setRoles(roles);
-
-    userService.save(user);
-
-    //region 记录积分log
-    if(siteConfig.getScore() != 0){
-      ScoreLog scoreLog = new ScoreLog();
-
-      scoreLog.setInTime(new Date());
-      scoreLog.setEvent(ScoreEventEnum.REGISTER.getEvent());
-      scoreLog.setChangeScore(user.getScore());
-      scoreLog.setScore(user.getScore());
-      scoreLog.setUser(user);
-
-      Map<String, Object> params = Maps.newHashMap();
-      params.put("scoreLog", scoreLog);
-      params.put("user", user);
-      String des = freemarkerUtil.format(scoreEventConfig.getTemplate().get(ScoreEventEnum.REGISTER.getName()), params);
-      scoreLog.setEventDescription(des);
-      scoreLogService.save(scoreLog);
-
-    }
-    //endregion 记录积分log
-    return Result.success();
-  }
-
-  private int width = 120;// 定义图片的width
-  private int height = 32;// 定义图片的height
-  private int codeCount = 4;// 定义图片上显示验证码的个数
-  private int xx = 22;
-  private int fontHeight = 26;
-  private int codeY = 25;
-  char[] codeSequence = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U',
-      'V', 'W', 'X', 'Y', '3', '4', '5', '6', '7', '8'};
-
-  /**
-   * 验证码生成
-   *
-   * @param req
-   * @param resp
-   * @throws IOException
-   */
-  @RequestMapping("/code")
-  public void getCode(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-    // 定义图像buffer
-    BufferedImage buffImg = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-    // Graphics2D gd = buffImg.createGraphics();
-    // Graphics2D gd = (Graphics2D) buffImg.getGraphics();
-    Graphics gd = buffImg.getGraphics();
-    // 创建一个随机数生成器类
-    Random random = new Random();
-    // 将图像填充为白色
-    gd.setColor(Color.WHITE);
-    gd.fillRect(0, 0, width, height);
-
-    // 创建字体，字体的大小应该根据图片的高度来定。
-    Font font = new Font("Fixedsys", Font.BOLD, fontHeight);
-    // 设置字体。
-    gd.setFont(font);
-
-    // 画边框。
-    gd.setColor(Color.BLACK);
-    gd.drawRect(0, 0, width - 1, height - 1);
-
-    // 随机产生40条干扰线，使图象中的认证码不易被其它程序探测到。
-    gd.setColor(Color.BLACK);
-    for (int i = 0; i < 40; i++) {
-      int x = random.nextInt(width);
-      int y = random.nextInt(height);
-      int xl = random.nextInt(20);
-      int yl = random.nextInt(20);
-      gd.drawLine(x, y, x + xl, y + yl);
+        }
+        //endregion 记录积分log
+        return Result.success();
     }
 
-    // randomCode用于保存随机产生的验证码，以便用户登录后进行验证。
-    StringBuffer randomCode = new StringBuffer();
-    int red, green, blue;
+    private int width = 120;// 定义图片的width
+    private int height = 32;// 定义图片的height
+    private int codeCount = 4;// 定义图片上显示验证码的个数
+    private int xx = 22;
+    private int fontHeight = 26;
+    private int codeY = 25;
+    char[] codeSequence = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U',
+            'V', 'W', 'X', 'Y', '3', '4', '5', '6', '7', '8'};
 
-    // 随机产生codeCount数字的验证码。
-    for (int i = 0; i < codeCount; i++) {
-      // 得到随机产生的验证码数字。
-      String code = String.valueOf(codeSequence[random.nextInt(29)]);
-      // 产生随机的颜色分量来构造颜色值，这样输出的每位数字的颜色值都将不同。
-      red = random.nextInt(255);
-      green = random.nextInt(255);
-      blue = random.nextInt(255);
+    /**
+     * 验证码生成
+     *
+     * @param req
+     * @param resp
+     * @throws IOException
+     */
+    @RequestMapping("/code")
+    public void getCode(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        // 定义图像buffer
+        BufferedImage buffImg = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        // Graphics2D gd = buffImg.createGraphics();
+        // Graphics2D gd = (Graphics2D) buffImg.getGraphics();
+        Graphics gd = buffImg.getGraphics();
+        // 创建一个随机数生成器类
+        Random random = new Random();
+        // 将图像填充为白色
+        gd.setColor(Color.WHITE);
+        gd.fillRect(0, 0, width, height);
 
-      // 用随机产生的颜色将验证码绘制到图像中。
-      gd.setColor(new Color(red, green, blue));
-      gd.drawString(code, (i + 1) * xx, codeY);
-      // 将产生的四个随机数组合在一起。
-      randomCode.append(code);
+        // 创建字体，字体的大小应该根据图片的高度来定。
+        Font font = new Font("Fixedsys", Font.BOLD, fontHeight);
+        // 设置字体。
+        gd.setFont(font);
+
+        // 画边框。
+        gd.setColor(Color.BLACK);
+        gd.drawRect(0, 0, width - 1, height - 1);
+
+        // 随机产生40条干扰线，使图象中的认证码不易被其它程序探测到。
+        gd.setColor(Color.BLACK);
+        for (int i = 0; i < 40; i++) {
+            int x = random.nextInt(width);
+            int y = random.nextInt(height);
+            int xl = random.nextInt(20);
+            int yl = random.nextInt(20);
+            gd.drawLine(x, y, x + xl, y + yl);
+        }
+
+        // randomCode用于保存随机产生的验证码，以便用户登录后进行验证。
+        StringBuffer randomCode = new StringBuffer();
+        int red, green, blue;
+
+        // 随机产生codeCount数字的验证码。
+        for (int i = 0; i < codeCount; i++) {
+            // 得到随机产生的验证码数字。
+            String code = String.valueOf(codeSequence[random.nextInt(29)]);
+            // 产生随机的颜色分量来构造颜色值，这样输出的每位数字的颜色值都将不同。
+            red = random.nextInt(255);
+            green = random.nextInt(255);
+            blue = random.nextInt(255);
+
+            // 用随机产生的颜色将验证码绘制到图像中。
+            gd.setColor(new Color(red, green, blue));
+            gd.drawString(code, (i + 1) * xx, codeY);
+            // 将产生的四个随机数组合在一起。
+            randomCode.append(code);
+        }
+        // 将四位数字的验证码保存到Session中。
+        HttpSession session = req.getSession();
+        session.setAttribute("index_code", randomCode.toString());
+        // 禁止图像缓存。
+        resp.setHeader("Pragma", "no-cache");
+        resp.setHeader("Cache-Control", "no-cache");
+        resp.setDateHeader("Expires", 0);
+        resp.setContentType("image/jpeg");
+        // 将图像输出到Servlet输出流中。
+        ServletOutputStream sos = resp.getOutputStream();
+        ImageIO.write(buffImg, "jpeg", sos);
     }
-    // 将四位数字的验证码保存到Session中。
-    HttpSession session = req.getSession();
-    session.setAttribute("index_code", randomCode.toString());
-    // 禁止图像缓存。
-    resp.setHeader("Pragma", "no-cache");
-    resp.setHeader("Cache-Control", "no-cache");
-    resp.setDateHeader("Expires", 0);
-    resp.setContentType("image/jpeg");
-    // 将图像输出到Servlet输出流中。
-    ServletOutputStream sos = resp.getOutputStream();
-    ImageIO.write(buffImg, "jpeg", sos);
-  }
 
-  @GetMapping("/sendEmailCode")
-  @ResponseBody
-  public Result sendEmailCode(String email) throws ApiException {
-    if (!StrUtil.check(email, StrUtil.check)) throw new ApiException("请输入正确的Email");
+    @GetMapping("/sendEmailCode")
+    @ResponseBody
+    public Result sendEmailCode(String email) throws ApiException {
+        if (!StrUtil.check(email, StrUtil.check)) throw new ApiException("请输入正确的Email");
 
-    User user = userService.findByEmail(email);
-    if (user != null) throw new ApiException("邮箱已经被使用");
+        User user = userService.findByEmail(email);
+        if (user != null) throw new ApiException("邮箱已经被使用");
 
-    try {
-      String genCode = codeService.genEmailCode(email);
-      MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-      MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "utf-8");
-      helper.setFrom(env.getProperty("spring.mail.username"));
-      helper.setTo(email);
-      helper.setSubject("注册验证码 - " + siteConfig.getName());
-      String htmlContent =
-          "<p>您好</p>" +
-          "<p>&nbsp;&nbsp;您的验证码为 <span style='color: red;'>" + genCode + "</span> , 请在10分钟内使用！</p><br>" +
-          "<small>本邮件为系统发出，请不要回复</small>";
-      helper.setText(htmlContent, true);
-      javaMailSender.send(mimeMessage);
-      return Result.success();
-    } catch (Exception e) {
-      log.error(e.getMessage());
-      return Result.error("邮件发送失败");
+        try {
+            String genCode = codeService.genEmailCode(email);
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "utf-8");
+            helper.setFrom(env.getProperty("spring.mail.username"));
+            helper.setTo(email);
+
+            Map<String, Object> params = Maps.newHashMap();
+            params.put("genCode", genCode);
+            helper.setSubject(freemarkerUtil.format(siteConfig.getMail().getSubject(), params));
+            helper.setText(freemarkerUtil.format(siteConfig.getMail().getContent(), params), true);
+            javaMailSender.send(mimeMessage);
+            return Result.success();
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return Result.error("邮件发送失败");
+        }
     }
-  }
 
 }

--- a/src/main/java/co/yiiu/web/front/IndexController.java
+++ b/src/main/java/co/yiiu/web/front/IndexController.java
@@ -162,6 +162,22 @@ public class IndexController extends BaseController {
         user.setScore(user.getScore() + score);
         userService.save(user);
 
+        // 记录积分log
+        ScoreLog scoreLog = new ScoreLog();
+
+        scoreLog.setInTime(new Date());
+        scoreLog.setEvent(ScoreEventEnum.DAILY_SIGN.getEvent());
+        scoreLog.setChangeScore(score);
+        scoreLog.setScore(user.getScore());
+        scoreLog.setUser(user);
+
+        Map<String, Object> params = Maps.newHashMap();
+        params.put("scoreLog", scoreLog);
+        params.put("user", user);
+        String des = freemarkerUtil.format(scoreEventConfig.getTemplate().get(ScoreEventEnum.DAILY_SIGN.getName()), params);
+        scoreLog.setEventDescription(des);
+        scoreLogService.save(scoreLog);
+
         // write remark to cookie
         writeAttendanceCookie(response, now, date2);
 
@@ -299,7 +315,7 @@ public class IndexController extends BaseController {
 
       scoreLog.setInTime(new Date());
       scoreLog.setEvent(ScoreEventEnum.REGISTER.getEvent());
-      scoreLog.setChangeScore(siteConfig.getCreateReplyScore());
+      scoreLog.setChangeScore(user.getScore());
       scoreLog.setScore(user.getScore());
       scoreLog.setUser(user);
 

--- a/src/main/java/co/yiiu/web/front/ReplyController.java
+++ b/src/main/java/co/yiiu/web/front/ReplyController.java
@@ -1,18 +1,24 @@
 package co.yiiu.web.front;
 
+import co.yiiu.config.ScoreEventConfig;
 import co.yiiu.config.SiteConfig;
 import co.yiiu.core.base.BaseController;
 import co.yiiu.core.base.BaseEntity;
 import co.yiiu.core.bean.Result;
 import co.yiiu.core.exception.ApiException;
+import co.yiiu.core.util.FreemarkerUtil;
 import co.yiiu.module.notification.model.NotificationEnum;
 import co.yiiu.module.notification.service.NotificationService;
 import co.yiiu.module.reply.model.Reply;
 import co.yiiu.module.reply.service.ReplyService;
+import co.yiiu.module.score.model.ScoreEventEnum;
+import co.yiiu.module.score.model.ScoreLog;
+import co.yiiu.module.score.service.ScoreLogService;
 import co.yiiu.module.topic.model.Topic;
 import co.yiiu.module.topic.service.TopicService;
 import co.yiiu.module.user.model.User;
 import co.yiiu.module.user.service.UserService;
+import com.google.common.collect.Maps;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.StringUtils;
@@ -21,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by tomoya.
@@ -31,142 +38,168 @@ import java.util.List;
 @RequestMapping("/reply")
 public class ReplyController extends BaseController {
 
-  @Autowired
-  private TopicService topicService;
-  @Autowired
-  private ReplyService replyService;
-  @Autowired
-  private NotificationService notificationService;
-  @Autowired
-  private UserService userService;
+    @Autowired
+    private TopicService topicService;
+    @Autowired
+    private ReplyService replyService;
+    @Autowired
+    private NotificationService notificationService;
+    @Autowired
+    private UserService userService;
 
-  @Autowired
-  private SiteConfig siteConfig;
+    @Autowired
+    private SiteConfig siteConfig;
+    @Autowired
+    FreemarkerUtil freemarkerUtil;
+    @Autowired
+    ScoreEventConfig scoreEventConfig;
 
-  /**
-   * 保存回复
-   *
-   * @param topicId
-   * @param content
-   * @return
-   */
-  @PostMapping("/save")
-  public String save(Integer topicId, String content, HttpServletResponse response) throws Exception {
-    User user = getUser();
-    if (user.isBlock()) throw new Exception("你的帐户已经被禁用，不能进行此项操作");
-    if (user.getScore() + siteConfig.getCreateReplyScore() < 0 ) throw new Exception("你的积分不足，不能评论");
-    if (StringUtils.isEmpty(content)) throw new Exception("回复内容不能为空");
+    @Autowired
+    ScoreLogService scoreLogService;
+    /**
+     * 保存回复
+     *
+     * @param topicId
+     * @param content
+     * @return
+     */
+    @PostMapping("/save")
+    public String save(Integer topicId, String content, HttpServletResponse response) throws Exception {
+        User user = getUser();
+        if (user.isBlock()) throw new Exception("你的帐户已经被禁用，不能进行此项操作");
+        if (user.getScore() + siteConfig.getCreateReplyScore() < 0) throw new Exception("你的积分不足，不能评论");
+        if (StringUtils.isEmpty(content)) throw new Exception("回复内容不能为空");
 
-    if (topicId != null) {
-      Topic topic = topicService.findById(topicId);
-      if (topic != null) {
-        Reply reply = new Reply();
-        reply.setUser(user);
-        reply.setTopic(topic);
-        reply.setInTime(new Date());
-        reply.setUp(0);
-        reply.setContent(content);
-        replyService.save(reply);
+        if (topicId != null) {
+            Topic topic = topicService.findById(topicId);
+            if (topic != null) {
+                Reply reply = new Reply();
+                reply.setUser(user);
+                reply.setTopic(topic);
+                reply.setInTime(new Date());
+                reply.setUp(0);
+                reply.setContent(content);
+                replyService.save(reply);
 
-        // update score
-        user.setScore(user.getScore() + siteConfig.getCreateReplyScore());
-        userService.save(user);
+                // update score
+                user.setScore(user.getScore() + siteConfig.getCreateReplyScore());
+                userService.save(user);
 
-        //回复+1
-        topic.setReplyCount(topic.getReplyCount() + 1);
-        topic.setLastReplyTime(new Date());
-        topicService.save(topic);
+                //回复+1
+                topic.setReplyCount(topic.getReplyCount() + 1);
+                topic.setLastReplyTime(new Date());
+                topicService.save(topic);
 
-        //给话题作者发送通知
-        if (user.getId() != topic.getUser().getId()) {
-          notificationService.sendNotification(getUser(), topic.getUser(), NotificationEnum.REPLY.name(), topic, content);
-        }
-        //给At用户发送通知
-        List<String> atUsers = BaseEntity.fetchUsers(null, content);
-        for (String u : atUsers) {
-          u = u.replace("@", "").trim();
-          if (!u.equals(user.getUsername())) {
-            User _user = userService.findByUsername(u);
-            if (_user != null) {
-              notificationService.sendNotification(user, _user, NotificationEnum.AT.name(), topic, content);
+
+                //region 记录积分log
+                ScoreLog scoreLog = new ScoreLog();
+
+                scoreLog.setInTime(new Date());
+                scoreLog.setEvent(ScoreEventEnum.REPLY_TOPIC.getEvent());
+                scoreLog.setChangeScore(siteConfig.getCreateReplyScore());
+                scoreLog.setScore(user.getScore());
+                scoreLog.setUser(user);
+
+                Map<String, Object> params = Maps.newHashMap();
+                params.put("scoreLog", scoreLog);
+                params.put("user", user);
+                params.put("topic", topic);
+                String des = freemarkerUtil.format(scoreEventConfig.getTemplate().get(ScoreEventEnum.REPLY_TOPIC.getName()), params);
+                scoreLog.setEventDescription(des);
+                scoreLogService.save(scoreLog);
+                //endregion 记录积分log
+
+
+                //给话题作者发送通知
+                if (user.getId() != topic.getUser().getId()) {
+                    notificationService.sendNotification(getUser(), topic.getUser(), NotificationEnum.REPLY.name(), topic, content);
+                }
+                //给At用户发送通知
+                List<String> atUsers = BaseEntity.fetchUsers(null, content);
+                for (String u : atUsers) {
+                    u = u.replace("@", "").trim();
+                    if (!u.equals(user.getUsername())) {
+                        User _user = userService.findByUsername(u);
+                        if (_user != null) {
+                            notificationService.sendNotification(user, _user, NotificationEnum.AT.name(), topic, content);
+                        }
+                    }
+                }
+                return redirect(response, "/topic/" + topicId);
             }
-          }
         }
-        return redirect(response, "/topic/" + topicId);
-      }
+        return redirect(response, "/");
     }
-    return redirect(response, "/");
-  }
 
-  /**
-   * 点赞
-   *
-   * @param id
-   * @return
-   * @throws ApiException
-   */
-  @GetMapping("/{id}/up")
-  @ResponseBody
-  public Result up(@PathVariable Integer id) throws ApiException {
-    User user = getUser();
-    Reply _reply = replyService.findById(id);
+    /**
+     * 点赞
+     *
+     * @param id
+     * @return
+     * @throws ApiException
+     */
+    @GetMapping("/{id}/up")
+    @ResponseBody
+    public Result up(@PathVariable Integer id) throws ApiException {
+        User user = getUser();
+        Reply _reply = replyService.findById(id);
 
-    if (_reply == null) throw new ApiException("回复不存在");
-    if (user.getId() == _reply.getUser().getId()) throw new ApiException("不能给自己的回复点赞");
+        if (_reply == null) throw new ApiException("回复不存在");
+        if (user.getId() == _reply.getUser().getId()) throw new ApiException("不能给自己的回复点赞");
 
-    Reply reply = replyService.up(user.getId(), _reply);
-    return Result.success(reply.getUpDown());
-  }
+        Reply reply = replyService.up(user.getId(), _reply);
+        return Result.success(reply.getUpDown());
+    }
 
-  /**
-   * 取消点赞
-   *
-   * @param id
-   * @return
-   * @throws ApiException
-   */
-  @GetMapping("/{id}/cancelUp")
-  @ResponseBody
-  public Result cancelUp(@PathVariable Integer id) throws ApiException {
-    User user = getUser();
-    Reply reply = replyService.cancelUp(user.getId(), id);
-    if (reply == null) throw new ApiException("回复不存在");
-    return Result.success(reply.getUpDown());
-  }
+    /**
+     * 取消点赞
+     *
+     * @param id
+     * @return
+     * @throws ApiException
+     */
+    @GetMapping("/{id}/cancelUp")
+    @ResponseBody
+    public Result cancelUp(@PathVariable Integer id) throws ApiException {
+        User user = getUser();
+        Reply reply = replyService.cancelUp(user.getId(), id);
+        if (reply == null) throw new ApiException("回复不存在");
+        return Result.success(reply.getUpDown());
+    }
 
-  /**
-   * 踩
-   *
-   * @param id
-   * @return
-   * @throws ApiException
-   */
-  @GetMapping("/{id}/down")
-  @ResponseBody
-  public Result down(@PathVariable Integer id) throws ApiException {
-    User user = getUser();
-    Reply _reply = replyService.findById(id);
+    /**
+     * 踩
+     *
+     * @param id
+     * @return
+     * @throws ApiException
+     */
+    @GetMapping("/{id}/down")
+    @ResponseBody
+    public Result down(@PathVariable Integer id) throws ApiException {
+        User user = getUser();
+        Reply _reply = replyService.findById(id);
 
-    if (_reply == null) throw new ApiException("回复不存在");
-    if (user.getId() == _reply.getUser().getId()) throw new ApiException("不能给自己的回复点赞");
+        if (_reply == null) throw new ApiException("回复不存在");
+        if (user.getId() == _reply.getUser().getId()) throw new ApiException("不能给自己的回复点赞");
 
-    Reply reply = replyService.down(user.getId(), _reply);
-    return Result.success(reply.getUpDown());
-  }
+        Reply reply = replyService.down(user.getId(), _reply);
+        return Result.success(reply.getUpDown());
+    }
 
-  /**
-   * 取消踩
-   *
-   * @param id
-   * @return
-   * @throws ApiException
-   */
-  @GetMapping("/{id}/cancelDown")
-  @ResponseBody
-  public Result cancelDown(@PathVariable Integer id) throws ApiException {
-    User user = getUser();
-    Reply reply = replyService.cancelDown(user.getId(), id);
-    if (reply == null) throw new ApiException("回复不存在");
-    return Result.success(reply.getUpDown());
-  }
+    /**
+     * 取消踩
+     *
+     * @param id
+     * @return
+     * @throws ApiException
+     */
+    @GetMapping("/{id}/cancelDown")
+    @ResponseBody
+    public Result cancelDown(@PathVariable Integer id) throws ApiException {
+        User user = getUser();
+        Reply reply = replyService.cancelDown(user.getId(), id);
+        if (reply == null) throw new ApiException("回复不存在");
+        return Result.success(reply.getUpDown());
+    }
 }

--- a/src/main/java/co/yiiu/web/front/TopicController.java
+++ b/src/main/java/co/yiiu/web/front/TopicController.java
@@ -1,15 +1,21 @@
 package co.yiiu.web.front;
 
+import co.yiiu.config.ScoreEventConfig;
 import co.yiiu.config.SiteConfig;
 import co.yiiu.core.base.BaseController;
 import co.yiiu.core.util.DateUtil;
+import co.yiiu.core.util.FreemarkerUtil;
 import co.yiiu.module.collect.service.CollectService;
 import co.yiiu.module.node.model.Node;
 import co.yiiu.module.node.service.NodeService;
+import co.yiiu.module.score.model.ScoreEventEnum;
+import co.yiiu.module.score.model.ScoreLog;
+import co.yiiu.module.score.service.ScoreLogService;
 import co.yiiu.module.topic.model.Topic;
 import co.yiiu.module.topic.service.TopicService;
 import co.yiiu.module.user.model.User;
 import co.yiiu.module.user.service.UserService;
+import com.google.common.collect.Maps;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -22,6 +28,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.servlet.http.HttpServletResponse;
 import java.util.Date;
+import java.util.Map;
 
 /**
  * Created by tomoya.
@@ -42,7 +49,13 @@ public class TopicController extends BaseController {
   private UserService userService;
   @Autowired
   private SiteConfig siteConfig;
+  @Autowired
+  FreemarkerUtil freemarkerUtil;
+  @Autowired
+  ScoreEventConfig scoreEventConfig;
 
+  @Autowired
+  ScoreLogService scoreLogService;
   /**
    * 话题详情
    *
@@ -140,6 +153,26 @@ public class TopicController extends BaseController {
       // update score
       user.setScore(user.getScore() + siteConfig.getCreateTopicScore());
       userService.save(user);
+
+
+      //region 记录积分log
+      ScoreLog scoreLog = new ScoreLog();
+
+      scoreLog.setInTime(new Date());
+      scoreLog.setEvent(ScoreEventEnum.CREATE_TOPIC.getEvent());
+      scoreLog.setChangeScore(siteConfig.getCreateReplyScore());
+      scoreLog.setScore(user.getScore());
+      scoreLog.setUser(user);
+
+      Map<String, Object> params = Maps.newHashMap();
+      params.put("scoreLog", scoreLog);
+      params.put("user", user);
+      params.put("topic", topic);
+      String des = freemarkerUtil.format(scoreEventConfig.getTemplate().get(ScoreEventEnum.CREATE_TOPIC.getName()), params);
+      scoreLog.setEventDescription(des);
+      scoreLogService.save(scoreLog);
+      //endregion 记录积分log
+
 
       //节点的话题数加一
       node.setTopicCount(node.getTopicCount() + 1);

--- a/src/main/java/co/yiiu/web/front/TopicController.java
+++ b/src/main/java/co/yiiu/web/front/TopicController.java
@@ -160,7 +160,7 @@ public class TopicController extends BaseController {
 
       scoreLog.setInTime(new Date());
       scoreLog.setEvent(ScoreEventEnum.CREATE_TOPIC.getEvent());
-      scoreLog.setChangeScore(siteConfig.getCreateReplyScore());
+      scoreLog.setChangeScore(siteConfig.getCreateTopicScore());
       scoreLog.setScore(user.getScore());
       scoreLog.setUser(user);
 

--- a/src/main/java/co/yiiu/web/front/UserController.java
+++ b/src/main/java/co/yiiu/web/front/UserController.java
@@ -6,9 +6,12 @@ import co.yiiu.core.bean.Result;
 import co.yiiu.core.exception.ApiException;
 import co.yiiu.core.util.identicon.Identicon;
 import co.yiiu.core.util.security.Base64Helper;
+import co.yiiu.module.score.model.ScoreLog;
+import co.yiiu.module.score.service.ScoreLogService;
 import co.yiiu.module.user.model.User;
 import co.yiiu.module.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -32,249 +35,248 @@ import java.util.*;
 @RequestMapping("/user")
 public class UserController extends BaseController {
 
-  @Autowired
-  private UserService userService;
-  @Autowired
-  private Identicon identicon;
-  @Autowired
-  private SiteConfig siteConfig;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private Identicon identicon;
+    @Autowired
+    private SiteConfig siteConfig;
+    @Autowired
+    private ScoreLogService scoreLogService;
 
-  /**
-   * 个人资料
-   *
-   * @param username
-   * @param model
-   * @return
-   */
-  @GetMapping("/{username}")
-  public String profile(@PathVariable String username, Model model) {
-    model.addAttribute("username", username);
-    return "front/user/info";
-  }
-
-  /**
-   * 用户发布的所有话题
-   *
-   * @param username
-   * @return
-   */
-  @GetMapping("/{username}/topics")
-  public String topics(@PathVariable String username, Integer p, Model model) {
-    model.addAttribute("username", username);
-    model.addAttribute("p", p);
-    return "front/user/topics";
-  }
-
-  /**
-   * 用户发布的所有回复
-   *
-   * @param username
-   * @return
-   */
-  @GetMapping("/{username}/replies")
-  public String replies(@PathVariable String username, Integer p, Model model) {
-    model.addAttribute("username", username);
-    model.addAttribute("p", p);
-    return "front/user/replies";
-  }
-
-  /**
-   * 用户收藏的所有话题
-   *
-   * @param username
-   * @return
-   */
-  @GetMapping("/{username}/collects")
-  public String collects(@PathVariable String username, Integer p, Model model) {
-    model.addAttribute("username", username);
-    model.addAttribute("p", p);
-    return "front/user/collects";
-  }
-
-  /**
-   * 进入用户个人设置页面
-   *
-   * @param model
-   * @return
-   */
-  @GetMapping("/profile")
-  public String setting(Model model) {
-    model.addAttribute("user", getUser());
-    return "front/user/setting/profile";
-  }
-
-  /**
-   * 更新用户的个人设置
-   *
-   * @param email
-   * @param url
-   * @param bio
-   * @param response
-   * @return
-   */
-  @PostMapping("/profile")
-  public String updateUserInfo(String email, String url, String bio, HttpServletResponse response) throws Exception {
-    User user = getUser();
-    if (user.isBlock())
-      throw new Exception("你的帐户已经被禁用，不能进行此项操作");
-    user.setEmail(email);
-    if (bio != null && bio.trim().length() > 0) user.setBio(bio);
-    user.setUrl(url);
-    userService.save(user);
-    return redirect(response, "/user/" + user.getUsername());
-  }
-
-  /**
-   * 修改头像
-   *
-   * @param model
-   * @return
-   */
-  @GetMapping("/changeAvatar")
-  public String changeAvatar(Model model) {
-    model.addAttribute("user", getUser());
-    return "front/user/setting/changeAvatar";
-  }
-
-  /**
-   * 保存头像
-   *
-   * @param avatar
-   * @return
-   * @throws ApiException
-   */
-  @PostMapping("changeAvatar")
-  @ResponseBody
-  public Result changeAvatar(String avatar) throws ApiException, IOException {
-    if (StringUtils.isEmpty(avatar)) throw new ApiException("头像不能为空");
-    String _avatar = avatar.substring(avatar.indexOf(",") + 1, avatar.length());
-    User user = getUser();
-    byte[] bytes;
-    try {
-      bytes = Base64Helper.decode(_avatar);
-    } catch (Exception e) {
-      e.printStackTrace();
-      throw new ApiException("头像格式不正确");
+    /**
+     * 个人资料
+     *
+     * @param username
+     * @param model
+     * @return
+     */
+    @GetMapping("/{username}")
+    public String profile(@PathVariable String username, Model model) {
+        model.addAttribute("username", username);
+        return "front/user/info";
     }
-    ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-    BufferedImage bufferedImage = ImageIO.read(bais);
-    String __avatar = identicon.saveFile(user.getUsername(), bufferedImage);
-    user.setAvatar(__avatar);
-    userService.save(user);
-    bais.close();
-    return Result.success();
-  }
 
-  @GetMapping("/changePassword")
-  public String changePassword() {
-    return "front/user/setting/changePassword";
-  }
-
-  /**
-   * 修改密码
-   *
-   * @param oldPassword
-   * @param newPassword
-   * @param model
-   * @return
-   */
-  @PostMapping("/changePassword")
-  public String changePassword(String oldPassword, String newPassword, Model model) throws Exception {
-    User user = getUser();
-    if (user.isBlock())
-      throw new Exception("你的帐户已经被禁用，不能进行此项操作");
-    if (new BCryptPasswordEncoder().matches(oldPassword, user.getPassword())) {
-      user.setPassword(new BCryptPasswordEncoder().encode(newPassword));
-      userService.save(user);
-      model.addAttribute("changePasswordErrorMsg", "修改成功，请重新登录");
-    } else {
-      model.addAttribute("changePasswordErrorMsg", "旧密码不正确");
+    /**
+     * 用户发布的所有话题
+     *
+     * @param username
+     * @return
+     */
+    @GetMapping("/{username}/topics")
+    public String topics(@PathVariable String username, Integer p, Model model) {
+        model.addAttribute("username", username);
+        model.addAttribute("p", p);
+        return "front/user/topics";
     }
-    model.addAttribute("user", getUser());
-    return "front/user/setting/changePassword";
-  }
 
-  /**
-   * user accessToken page
-   *
-   * @param model
-   * @return
-   */
-  @GetMapping("/accessToken")
-  public String accessToken(Model model) {
-    model.addAttribute("user", getUser());
-    return "/front/user/setting/accessToken";
-  }
+    /**
+     * 用户发布的所有回复
+     *
+     * @param username
+     * @return
+     */
+    @GetMapping("/{username}/replies")
+    public String replies(@PathVariable String username, Integer p, Model model) {
+        model.addAttribute("username", username);
+        model.addAttribute("p", p);
+        return "front/user/replies";
+    }
 
-  /**
-   * 刷新token
-   *
-   * @param response
-   * @return
-   */
-  @GetMapping("/refreshToken")
-  public String refreshToken(HttpServletResponse response) {
-    User user = getUser();
-    user.setToken(UUID.randomUUID().toString());
-    userService.save(user);
-    return redirect(response, "/user/accessToken");
-  }
+    /**
+     * 用户收藏的所有话题
+     *
+     * @param username
+     * @return
+     */
+    @GetMapping("/{username}/collects")
+    public String collects(@PathVariable String username, Integer p, Model model) {
+        model.addAttribute("username", username);
+        model.addAttribute("p", p);
+        return "front/user/collects";
+    }
 
-  /**
-   * user upload file list
-   *
-   * @param model
-   * @return
-   */
-  @GetMapping("/space")
-  public String space(Model model) {
-    long count = 0;
-    String userUploadPath = getUsername() + "/";
-    List list = new ArrayList();
-    File file = new File(siteConfig.getUploadPath() + userUploadPath);
-    if (file.exists()) {
-      for (File f : file.listFiles()) {
-        Map map = new HashMap();
-        if (f.isDirectory() && f.listFiles().length > 0) {
-          String dirName = f.getName();
-          List fileList = new ArrayList();
-          for (File f1 : f.listFiles()) {
-            count += f1.length();
-            Map m = new HashMap();
-            m.put("fileName", f1.getName());
-            m.put("fileUrl", siteConfig.getStaticUrl() + userUploadPath + dirName + "/" + f1.getName());
-            fileList.add(m);
-          }
-          map.put("dirName", dirName);
-          map.put("fileList", fileList);
-          list.add(map);
+    /**
+     * 进入用户个人设置页面
+     *
+     * @param model
+     * @return
+     */
+    @GetMapping("/profile")
+    public String setting(Model model) {
+        model.addAttribute("user", getUser());
+        return "front/user/setting/profile";
+    }
+
+    /**
+     * 更新用户的个人设置
+     *
+     * @param email
+     * @param url
+     * @param bio
+     * @param response
+     * @return
+     */
+    @PostMapping("/profile")
+    public String updateUserInfo(String email, String url, String bio, HttpServletResponse response) throws Exception {
+        User user = getUser();
+        if (user.isBlock())
+            throw new Exception("你的帐户已经被禁用，不能进行此项操作");
+        user.setEmail(email);
+        if (bio != null && bio.trim().length() > 0) user.setBio(bio);
+        user.setUrl(url);
+        userService.save(user);
+        return redirect(response, "/user/" + user.getUsername());
+    }
+
+    /**
+     * 修改头像
+     *
+     * @param model
+     * @return
+     */
+    @GetMapping("/changeAvatar")
+    public String changeAvatar(Model model) {
+        model.addAttribute("user", getUser());
+        return "front/user/setting/changeAvatar";
+    }
+
+    /**
+     * 保存头像
+     *
+     * @param avatar
+     * @return
+     * @throws ApiException
+     */
+    @PostMapping("changeAvatar")
+    @ResponseBody
+    public Result changeAvatar(String avatar) throws ApiException, IOException {
+        if (StringUtils.isEmpty(avatar)) throw new ApiException("头像不能为空");
+        String _avatar = avatar.substring(avatar.indexOf(",") + 1, avatar.length());
+        User user = getUser();
+        byte[] bytes;
+        try {
+            bytes = Base64Helper.decode(_avatar);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new ApiException("头像格式不正确");
         }
-      }
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        BufferedImage bufferedImage = ImageIO.read(bais);
+        String __avatar = identicon.saveFile(user.getUsername(), bufferedImage);
+        user.setAvatar(__avatar);
+        userService.save(user);
+        bais.close();
+        return Result.success();
     }
-    model.addAttribute("user", getUser());
-    model.addAttribute("count", (double) count / 1000000);
-    model.addAttribute("list", list);
-    return "front/user/setting/space";
-  }
 
-  /**
-   * delete user upload file
-   *
-   * @param dirName
-   * @param fileName
-   * @return
-   */
-  @PostMapping("/space/deleteFile")
-  @ResponseBody
-  public Result deleteFile(String dirName, String fileName) {
-    String userUploadPath = getUsername() + "/";
-    File file = new File(siteConfig.getUploadPath() + userUploadPath + dirName + "/" + fileName);
-    if (file.exists()) {
-      if (file.delete()) return Result.success();
-      else return Result.error("删除失败");
-    } else {
-      return Result.error("文件不存在");
+    @GetMapping("/changePassword")
+    public String changePassword() {
+        return "front/user/setting/changePassword";
     }
-  }
+
+    /**
+     * 修改密码
+     *
+     * @param oldPassword
+     * @param newPassword
+     * @param model
+     * @return
+     */
+    @PostMapping("/changePassword")
+    public String changePassword(String oldPassword, String newPassword, Model model) throws Exception {
+        User user = getUser();
+        if (user.isBlock())
+            throw new Exception("你的帐户已经被禁用，不能进行此项操作");
+        if (new BCryptPasswordEncoder().matches(oldPassword, user.getPassword())) {
+            user.setPassword(new BCryptPasswordEncoder().encode(newPassword));
+            userService.save(user);
+            model.addAttribute("changePasswordErrorMsg", "修改成功，请重新登录");
+        } else {
+            model.addAttribute("changePasswordErrorMsg", "旧密码不正确");
+        }
+        model.addAttribute("user", getUser());
+        return "front/user/setting/changePassword";
+    }
+
+    /**
+     * user accessToken page
+     *
+     * @param model
+     * @return
+     */
+    @GetMapping("/accessToken")
+    public String accessToken(Model model) {
+        model.addAttribute("user", getUser());
+        return "/front/user/setting/accessToken";
+    }
+
+    /**
+     * 刷新token
+     *
+     * @param response
+     * @return
+     */
+    @GetMapping("/refreshToken")
+    public String refreshToken(HttpServletResponse response) {
+        User user = getUser();
+        user.setToken(UUID.randomUUID().toString());
+        userService.save(user);
+        return redirect(response, "/user/accessToken");
+    }
+
+    /**
+     * user upload file list
+     *
+     * @param model
+     * @return
+     */
+    @GetMapping("/space")
+    public String space(Model model) {
+        long count = 0;
+        String userUploadPath = getUsername() + "/";
+        List list = new ArrayList();
+        File file = new File(siteConfig.getUploadPath() + userUploadPath);
+        if (file.exists()) {
+            for (File f : file.listFiles()) {
+                Map map = new HashMap();
+                if (f.isDirectory() && f.listFiles().length > 0) {
+                    String dirName = f.getName();
+                    List fileList = new ArrayList();
+                    for (File f1 : f.listFiles()) {
+                        count += f1.length();
+                        Map m = new HashMap();
+                        m.put("fileName", f1.getName());
+                        m.put("fileUrl", siteConfig.getStaticUrl() + userUploadPath + dirName + "/" + f1.getName());
+                        fileList.add(m);
+                    }
+                    map.put("dirName", dirName);
+                    map.put("fileList", fileList);
+                    list.add(map);
+                }
+            }
+        }
+        model.addAttribute("user", getUser());
+        model.addAttribute("count", (double) count / 1000000);
+        model.addAttribute("list", list);
+        return "front/user/setting/space";
+    }
+
+    /**
+     * query user score history
+     *
+     * @param p     page
+     * @param model
+     * @return
+     */
+    @GetMapping("/scoreLog")
+    public String scoreLog(Integer p, Model model) {
+        User user = getUser();
+
+        model.addAttribute("scoreLogs", scoreLogService.findScoreByUser(p, siteConfig.getPageSize(), user));
+
+        return "front/user/setting/scoreLog";
+    }
+
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,7 +88,12 @@ site:
     attendanceMaxAge: 86400
     attendanceName: attendance
     rememberMeExpireDay: 30 # 记住我30天
-
+  mail:
+    subject: 注册验证码 - ${site.name}
+    content: |
+          <p>您好</p>
+          <p>&nbsp;&nbsp;您的验证码为 <span style='color: red;'>${genCode}</span> , 请在10分钟内使用！</p><br>
+          <small>本邮件为系统发出，请不要回复</small>
 
 score:
   template:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,7 +92,7 @@ site:
 
 score:
   template:
-    dailySign: 每日签到获得积分${scoreLog.changeScore}
+    dailySign: 每日签到获得${scoreLog.changeScore}积分
     createTopic: 发表主题[<a href="/topic/${topic.id}" target="_blank">${topic.title?html}</a>],扣减${scoreLog.changeScore}积分
     replyTopic: 回复主题[<a href="/topic/${topic.id}"  target="_blank">${topic.title?html}</a>],扣减${scoreLog.changeScore}积分
     register: 用户注册奖励${scoreLog.changeScore}积分

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,3 +88,10 @@ site:
     attendanceMaxAge: 86400
     attendanceName: attendance
     rememberMeExpireDay: 30 # 记住我30天
+
+
+score:
+  template:
+    dailySign: 每日签到获得积分${scoreLog.changeScore}
+    createTopic: 发表主题[<a href="/topic/${topic.id}" target="_blank">${topic.title?html}</a>],扣减${scoreLog.changeScore}积分
+    replyTopic: 回复主题[<a href="/topic/${topic.id}"  target="_blank">${topic.title?html}</a>],扣减${scoreLog.changeScore}积分

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,3 +95,4 @@ score:
     dailySign: 每日签到获得积分${scoreLog.changeScore}
     createTopic: 发表主题[<a href="/topic/${topic.id}" target="_blank">${topic.title?html}</a>],扣减${scoreLog.changeScore}积分
     replyTopic: 回复主题[<a href="/topic/${topic.id}"  target="_blank">${topic.title?html}</a>],扣减${scoreLog.changeScore}积分
+    register: 用户注册奖励${scoreLog.changeScore}积分

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -52,6 +52,18 @@
       memoryStoreEvictionPolicy="LRU"/>
 
   <cache
+          name="scoreLogs"
+          maxElementsInMemory="10000"
+          eternal="false"
+          timeToIdleSeconds="5"
+          timeToLiveSeconds="5"
+          overflowToDisk="true"
+          maxElementsOnDisk="10000000"
+          diskPersistent="true"
+          diskExpiryThreadIntervalSeconds="120"
+          memoryStoreEvictionPolicy="LRU"/>
+
+  <cache
       name="notifications"
       maxElementsInMemory="10000"
       eternal="false"

--- a/views/default/templates/admin/components/reply_list.ftl
+++ b/views/default/templates/admin/components/reply_list.ftl
@@ -7,7 +7,7 @@
         ${model.formatDate(reply.inTime)}
         回复了
         <a href="/user/${reply.topic.user.username}">${reply.topic.user.username}</a>
-        创建的话题 › <a href="/topic/${reply.topic.id}">${reply.topic.title}</a>
+        创建的话题 › <a href="/topic/${reply.topic.id}">${reply.topic.title!?html}</a>
       </td>
     </tr>
     <tr>

--- a/views/default/templates/admin/reply/edit.ftl
+++ b/views/default/templates/admin/reply/edit.ftl
@@ -1,10 +1,10 @@
 <#include "../../front/common/layout.ftl"/>
-<@html page_title="${reply.topic.title} 回复编辑">
+<@html page_title="${reply.topic.title!} 回复编辑">
 <div class="row">
   <div class="col-md-9">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <a href="/">主页</a> / <a href="/topic/${reply.topic.id}">${reply.topic.title}</a> / 编辑回复
+        <a href="/">主页</a> / <a href="/topic/${reply.topic.id}">${reply.topic.title!?html}</a> / 编辑回复
       </div>
       <div class="panel-body">
         <form action="/admin/reply/update" method="post" id="editorForm">

--- a/views/default/templates/admin/topic/list.ftl
+++ b/views/default/templates/admin/topic/list.ftl
@@ -16,7 +16,7 @@
             <#list page.getContent() as topic>
             <tr>
               <td>
-                <a href="/topic/${topic.id}" target="_blank">${topic.title!}</a>
+                <a href="/topic/${topic.id}" target="_blank">${topic.title!?html}</a>
               </td>
               <td>${model.formatDate(topic.inTime)}</td>
               <td>

--- a/views/default/templates/front/common/setting_menu.ftl
+++ b/views/default/templates/front/common/setting_menu.ftl
@@ -6,6 +6,7 @@
     <a href="/user/changePassword" class="list-group-item <#if setting_menu_tab == 'changePassword'>active</#if>">修改密码</a>
     <a href="/user/accessToken" class="list-group-item <#if setting_menu_tab == 'accessToken'>active</#if>">用户令牌</a>
     <a href="/user/space" class="list-group-item <#if setting_menu_tab == 'space'>active</#if>">个人空间</a>
+    <a href="/user/scoreLog" class="list-group-item <#if setting_menu_tab == 'scoreLog'>active</#if>">积分记录</a>
   </div>
 </div>
 </#macro>

--- a/views/default/templates/front/components/author_info.ftl
+++ b/views/default/templates/front/components/author_info.ftl
@@ -17,7 +17,7 @@
       </div>
       <#if author.bio?? && author.bio != "">
         <div style="color: #7A7A7A; font-size: 12px; margin-top:5px;">
-          <i>“ ${author.bio!} ” </i>
+          <i>“ ${author.bio!?html} ” </i>
         </div>
       </#if>
     </div>

--- a/views/default/templates/front/components/search_result.ftl
+++ b/views/default/templates/front/components/search_result.ftl
@@ -3,7 +3,7 @@
   <#list topics as topic>
     <tr>
       <td>
-        <a href="/topic/${topic.id!}" target="_blank" style="font-size: 16px;">${topic.title!}</a>
+        <a href="/topic/${topic.id!}" target="_blank" style="font-size: 16px;">${topic.title!?html}</a>
       </td>
     </tr>
     <tr>

--- a/views/default/templates/front/components/user_collects.ftl
+++ b/views/default/templates/front/components/user_collects.ftl
@@ -14,7 +14,7 @@
         <div class="media">
           <div class="media-body">
             <div class="title">
-              <a href="/topic/${collect.topic.id!}">${collect.topic.title!}</a>
+              <a href="/topic/${collect.topic.id!}">${collect.topic.title!?html}</a>
             </div>
             <p>
               <a href="/go/${collect.topic.node.value!}">${collect.topic.node.name!}</a>

--- a/views/default/templates/front/components/user_info.ftl
+++ b/views/default/templates/front/components/user_info.ftl
@@ -12,7 +12,7 @@
           <div class="media-heading">
             <a href="/user/${user.username!}">${user.username!}</a>
             <div style="color: #7A7A7A; font-size: 12px; margin-top:5px;">
-              <i>${user.bio!"这家伙很懒，什么都没有留下"}</i>
+              <i>${(user.bio!"这家伙很懒，什么都没有留下")?html}</i>
             </div>
           </div>
         </div>

--- a/views/default/templates/front/components/user_replies.ftl
+++ b/views/default/templates/front/components/user_replies.ftl
@@ -14,7 +14,7 @@
               ${model.formatDate(reply.inTime)!}
               回复了
               <a href="/user/${reply.user.username}">${reply.user.username}</a>
-              创建的话题 › <a href="/topic/${reply.topic.id}">${reply.topic.title}</a>
+              创建的话题 › <a href="/topic/${reply.topic.id}">${reply.topic.title!?html}</a>
             </td>
           </tr>
           <tr class="user_replies">

--- a/views/default/templates/front/components/user_topics.ftl
+++ b/views/default/templates/front/components/user_topics.ftl
@@ -12,7 +12,7 @@
           <div class="media">
             <div class="media-body">
               <div class="title">
-                <a href="/topic/${topic.id!}">${topic.title!}</a>
+                <a href="/topic/${topic.id!}">${topic.title!?html}</a>
               </div>
               <p>
                 <a href="/go/${topic.node.value!}">${topic.node.name!}</a>

--- a/views/default/templates/front/index.ftl
+++ b/views/default/templates/front/index.ftl
@@ -50,7 +50,7 @@
               </div>
               <div class="media-body">
                 <div class="title">
-                  <a href="/topic/${topic.id!}">${topic.title!}</a>
+                  <a href="/topic/${topic.id!}">${topic.title!?html}</a>
                 </div>
                 <p class="gray">
                   <#if topic.top == true>

--- a/views/default/templates/front/node/list.ftl
+++ b/views/default/templates/front/node/list.ftl
@@ -21,7 +21,7 @@
             </div>
             <div class="media-body">
               <div class="title">
-                <a href="/topic/${topic.id!}">${topic.title!}</a>
+                <a href="/topic/${topic.id!}">${topic.title!?html}</a>
               </div>
               <p class="gray">
                 <#if topic.top == true>

--- a/views/default/templates/front/notification/list.ftl
+++ b/views/default/templates/front/notification/list.ftl
@@ -24,7 +24,7 @@
                   <#elseif notification.action == "AT">
                     在回复
                   </#if>
-                  <a href="/topic/${notification.topic.id}">${notification.topic.title}</a>
+                  <a href="/topic/${notification.topic.id}">${notification.topic.title!?html}</a>
                   <#if notification.action == "REPLY">
                     里回复了你
                   <#elseif notification.action == "AT">

--- a/views/default/templates/front/top100.ftl
+++ b/views/default/templates/front/top100.ftl
@@ -26,7 +26,7 @@
               <td>
                 <i>
                   <#if user.bio??>
-                    ${user.bio}
+                    ${user.bio?html}
                   <#else>
                     "这家伙很懒，什么都没有留下"
                   </#if>

--- a/views/default/templates/front/topic/detail.ftl
+++ b/views/default/templates/front/topic/detail.ftl
@@ -1,12 +1,12 @@
 <#include "../common/layout.ftl">
-<@html page_title="${topic.title}">
+<@html page_title="${topic.title!}">
 <div class="row">
   <div class="col-md-9">
     <div class="panel panel-default">
       <div class="panel-body topic-detail-header">
         <div class="media">
           <div class="media-body">
-            <h2 class="topic-detail-title">${topic.title!}</h2>
+            <h2 class="topic-detail-title">${topic.title!?html}</h2>
             <p class="gray">
               <#if topic.top == true>
                 <span class="label label-primary">置顶</span>
@@ -84,7 +84,7 @@
       <#if sec.isAuthenticated()>
         <div class="panel-footer">
           <a
-              href="javascript:window.open('http://service.weibo.com/share/share.php?url=${site.baseUrl!}/topic/${topic.id!}?r=${sec.getPrincipal()!}&title=${topic.title!}', '_blank', 'width=550,height=370'); recordOutboundLink(this, 'Share', 'weibo.com');">分享微博</a>&nbsp;
+              href="javascript:window.open('http://service.weibo.com/share/share.php?url=${site.baseUrl!}/topic/${topic.id!}?r=${sec.getPrincipal()!}&title=${topic.title!?html}', '_blank', 'width=550,height=370'); recordOutboundLink(this, 'Share', 'weibo.com');">分享微博</a>&nbsp;
           <#if collect??>
             <a href="/collect/${topic.id!}/delete">取消收藏</a>
           <#else>

--- a/views/default/templates/front/topic/edit.ftl
+++ b/views/default/templates/front/topic/edit.ftl
@@ -23,7 +23,7 @@
                 <a id="choiceNode" class="btn btn-default" onclick="javascript:;" data-toggle="modal"
                    data-target="#choiceModal">${topic.node.name!}</a>
               </span>
-              <input type="text" class="form-control" id="title" name="title" value="${topic.title!}" placeholder="标题">
+              <input type="text" class="form-control" id="title" name="title" value="${topic.title!?html}" placeholder="标题">
             </div>
           </div>
 

--- a/views/default/templates/front/user/info.ftl
+++ b/views/default/templates/front/user/info.ftl
@@ -15,11 +15,11 @@
               <h3 style="margin-top: 0">${currentUser.username!}</h3>
               <p>积分：<a href="/top100">${currentUser.score!0}</a></p>
               <#if currentUser.bio??>
-                <p><i class="gray">${currentUser.bio!}</i></p>
+                <p><i class="gray">${currentUser.bio!?html}</i></p>
               </#if>
               <div>收藏话题: <a href="/user/${currentUser.username}/collects">${collectCount!0}</a></div>
               <#if currentUser.url??>
-                <div>主页: <a href="${currentUser.url!}" target="_blank">${currentUser.url!}</a></div>
+                <div>主页: <a href="${currentUser.url!?html}" target="_blank">${currentUser.url!?html}</a></div>
               </#if>
               <div>入驻时间: ${model.formatDate(currentUser.inTime)}</div>
             </div>

--- a/views/default/templates/front/user/setting/profile.ftl
+++ b/views/default/templates/front/user/setting/profile.ftl
@@ -21,15 +21,15 @@
           </div>
           <div class="form-group">
             <label for="email">邮箱</label>
-            <input type="text" class="form-control" id="email" name="email" value="${user.email!}"/>
+            <input type="text" class="form-control" id="email" name="email" value="${user.email!?html}"/>
           </div>
           <div class="form-group">
             <label for="url">个人主页</label>
-            <input type="text" class="form-control" id="url" name="url" value="${user.url!}"/>
+            <input type="text" class="form-control" id="url" name="url" value="${user.url!?html}"/>
           </div>
           <div class="form-group">
             <label for="bio">个性签名</label>
-            <textarea class="form-control" name="bio" id="bio">${user.bio!}</textarea>
+            <textarea class="form-control" name="bio" id="bio">${user.bio!?html}</textarea>
           </div>
           <#if user.block == true>
             <button type="button" disabled="disabled" class="btn btn-default">保存设置</button>

--- a/views/default/templates/front/user/setting/scoreLog.ftl
+++ b/views/default/templates/front/user/setting/scoreLog.ftl
@@ -1,0 +1,40 @@
+<#include "../../common/layout.ftl"/>
+<@html page_title="个人积分记录" page_tab="setting">
+<div class="row">
+
+    <div class="col-md-3 hidden-sm hidden-xs">
+        <#include "../../common/setting_menu.ftl"/>
+    <@setting_menu setting_menu_tab="scoreLog"/>
+    </div>
+
+    <div class="col-md-9">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <a href="/">主页</a> / 个人积分记录
+            </div>
+            <div class="panel-body">
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <tr>
+                            <th>ID</th>
+                            <th>详情</th>
+                            <th>积分变动</th>
+                            <th>剩余积分</th>
+                            <th>添加日期</th>
+                        </tr>
+                        <#list scoreLogs.getContent() as scoreLog>
+                            <tr>
+                                <td>${scoreLog.id!}</td>
+                                <td>${scoreLog.eventDescription!}</td>
+                                <td>${scoreLog.changeScore!}</td>
+                                <td>${scoreLog.score!}</td>
+                                <td>${model.formatDate(scoreLog.inTime)!}</td>
+                            </tr>
+                        </#list>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</@html>


### PR DESCRIPTION
1.新增yiiu_score_log表,记录积分变更, 初步增加 注册  签到 发布 回复主题积分变更信息
ScoreEventConfig: 读取 application.yml 配置的记录详情模板
```yml
score:
  template:
    dailySign: 每日签到获得积分${scoreLog.changeScore}
    createTopic: 发表主题[<a href="/topic/${topic.id}" target="_blank">${topic.title?html}</a>],扣减${scoreLog.changeScore?abs}积分
    replyTopic: 回复主题[<a href="/topic/${topic.id}"  target="_blank">${topic.title?html}</a>],扣减${scoreLog.changeScore?abs}积分
    register: 用户注册奖励${scoreLog.changeScore}积分
```
2. 修复主题标题 , 用户网址,个性签名 的xss问题
由于后台校验不严格会出现xss, 暂时用freemarker的?html解决
主题内容部分markdown渲染理论上没有xss问题(猜测,具体没看实现)
其他可能还有,暂时未发现
3.注册邮件可配置

PS: 提两个建议
1. 建议把 controller 里面的 业务代码抽到service层,目前冗余到了controller,代码写起来很爽,但是会导致大量重复代码和混乱
2. 入参校验不严格,需要完善参数校验,不少接口入校验不严格,例如邮箱修改的时候未校验,所以会出现xss